### PR TITLE
add in refresh command

### DIFF
--- a/cmd/rapture/command_refresh.go
+++ b/cmd/rapture/command_refresh.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/daveadams/go-rapture/log"
+)
+
+// CommandRefresh implements the refreshing of credentials.
+func CommandRefresh(cmd string, args []string) int {
+	log.Tracef("[main] CommandRefresh(cmd='%s', args=%s)", cmd, args)
+
+	RequireWrap()
+
+	sess, err := CurrentSession()
+	if err != nil {
+		shgen.ErrEchof("ERROR: Could not load current Rapture session: %s", err)
+		return 1
+	}
+	sess.BaseCreds.ExportToEnvironment(shgen)
+
+	if cc, err := LoadCredentialsWithForce(sess.AssumedRoleAlias, true); err != nil {
+		shgen.ErrEchof("ERROR: %s", err)
+		return 1
+	} else {
+		shgen.Echof("Refreshed role '%s'", cc.RoleArn)
+		return 0
+	}
+}

--- a/cmd/rapture/helpers.go
+++ b/cmd/rapture/helpers.go
@@ -58,7 +58,11 @@ func CurrentSession() (*session.RaptureSession, error) {
 
 func LoadCredentials(id string) (*session.CachedCredentials, error) {
 	log.Tracef("main: LoadCredentials(id='%s')", id)
+	return LoadCredentialsWithForce(id, false)
+}
 
+func LoadCredentialsWithForce(id string, forceRefresh bool) (*session.CachedCredentials, error) {
+	log.Tracef("main: LoadCredentialsWithForce(id='%s', force_refresh='%t')", id, forceRefresh)
 	roles, err := config.LoadRoles()
 	if err != nil {
 		shgen.ErrEchof("WARNING: could not load role alias config: %s", err)
@@ -75,7 +79,7 @@ func LoadCredentials(id string) (*session.CachedCredentials, error) {
 		return nil, err
 	}
 
-	cc, err := sess.CredentialsForRole(arn)
+	cc, err := sess.GetCredentialsForRole(arn, forceRefresh)
 	if err != nil {
 		return nil, fmt.Errorf("Could not assume role '%s': %s", id, err)
 	}

--- a/cmd/rapture/main.go
+++ b/cmd/rapture/main.go
@@ -16,6 +16,7 @@ var cmdMap CommandMap = CommandMap{
 	"config":     CommandConfig,
 	"daemon":     CommandDaemon,
 	"init":       CommandInit,
+	"refresh":    CommandRefresh,
 	"reset":      CommandReset,
 	"resume":     CommandResume,
 	"role":       CommandRole,

--- a/session/cached_credentials.go
+++ b/session/cached_credentials.go
@@ -32,7 +32,14 @@ type CachedCredentials struct {
 // otherwise, try to assume the role
 // base credentials are stored with the sentinel role arn of BaseCredentialsArn
 func (s *RaptureSession) CredentialsForRole(arn string) (*CachedCredentials, error) {
-	log.Tracef("session: RaptureSession.CredentialsForRole(arn='%s')", arn)
+	return s.GetCredentialsForRole(arn, false)
+}
+
+// fetch cached credentials if they are valid and not yet expired, and force_refresh is not on
+// otherwise, try to assume the role
+// base credentials are stored with the sentinel role arn of BaseCredentialsArn
+func (s *RaptureSession) GetCredentialsForRole(arn string, forceRefresh bool) (*CachedCredentials, error) {
+	log.Tracef("session: RaptureSession.GetCredentialsForRole(arn='%s', forceRefresh='%t')", arn, forceRefresh)
 
 	rv := &CachedCredentials{
 		RoleArn: arn,
@@ -41,7 +48,7 @@ func (s *RaptureSession) CredentialsForRole(arn string) (*CachedCredentials, err
 
 	if ok, err := rv.load(); ok {
 		log.Debug("Loaded credentials from cache successfully")
-		if !rv.Creds.NearExpiration() {
+		if !rv.Creds.NearExpiration() && !forceRefresh {
 			log.Debug("These credentials are not expired!")
 			return rv, nil
 		}


### PR DESCRIPTION
the refresh command makes it so you can force refresh your credentials
if you know you're going to start running a long command you can
force in a refresh before hand