### PR TITLE
Replacing `go get` with `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ quickly.
 First, install the latest Rapture binary for your platform [from Github](https://github.com/daveadams/go-rapture/releases)
 and copy it to a directory in your PATH. Or if you prefer you can build it yourself (Go 1.12 or higher required):
 
-    $ go get -u github.com/daveadams/go-rapture/cmd/rapture
+    $ go install github.com/daveadams/go-rapture/cmd/rapture
 
 To configure your shell to load Rapture at startup, follow the instructions
 below for your specific shell.


### PR DESCRIPTION
I didn't change the version requirement from "Go 1.12" because that's still the overall version requirement, but if someone is following along with the README, they are more likely to be on a current version of Go than an older one.